### PR TITLE
Add Glossary page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/
 bin/hugo
 
 public/
+resources/_gen

--- a/assets/sass/_constants.scss
+++ b/assets/sass/_constants.scss
@@ -1,0 +1,64 @@
+// Colors
+$gray: #737373;
+$light-gray: lighten($gray, 52%);
+$medium-gray: lighten($gray, 35%);
+$dark-gray: darken($gray, 20%);
+
+// Font sizes
+$font-size--primary: 1rem;
+$font-size--s: 1.15rem;
+$font-size--m: 1.65rem;
+$font-size--l: 1.75rem;
+$font-size--xl: 2rem;
+$font-size--xxl: 2.25rem;
+$font-size--xxxl: 3rem;
+
+// Responsive breakpoints, corresponds to the BootStrap V4 ones
+$bp-xs: 0;
+$bp-xs-max: 575px;
+$bp-sm: 576px;
+$bp-md: 768px;
+$bp-lg: 992px;
+$bp-xl: 1200px;
+$bp-xxl: 1300px;
+
+// Embellishments
+$headerHeight: 6.875rem;
+$headerHeightLg: 8.125rem;
+$activeHeaderHeight: 5rem;
+$footerHeight: 7rem;
+
+// Z-index of different layers
+$modal-z: 110;
+$header-z: 100;
+$overlay-z: 75;
+$sidebar-z: 50;
+$banner-z: 20;
+$floating-button-z: 15;
+$glossary-letter-z: 10;
+$toolbar-button-z: 1;
+$promotion-z: -1;
+$footer-z: 0;
+
+// various manifest constants
+$border-radius: 4px;
+$button-border-radius: 28px;
+$header-link-spacing-xl: 1.875rem;
+$header-link-spacing-lg: .875rem;
+$header-link-spacing-xxl: 1.875rem;
+$section-margin: 3.625rem;
+$section-margin-md: 7rem;
+$panel-margin-top: 2.5rem;
+
+// Container widths
+$container-s: 750px;
+$container: 1040px;
+$container-l: 1440px;
+
+// popover style
+$popoverBorderColor: #777777;
+$popoverShadowColor: #777777;
+$popoverHeaderBackgroundColor: #{$light-gray};
+$popoverHeaderTextColor: var(--textColor);
+$popoverBackgroundColor: var(--backgroundColor);
+$popoverTextColor: var(--textColor);

--- a/assets/sass/glossary.scss
+++ b/assets/sass/glossary.scss
@@ -1,0 +1,52 @@
+@import "constants";
+
+.glossary {
+    .trampolines {
+        font-size: $font-size--l;
+        text-align: center;
+        padding-top: .8rem;
+
+        @media print {
+            display: none;
+        }
+    }
+
+    .entries {
+        .letter {
+            @media screen {
+                dt:target::before {
+                    height: calc(#{$headerHeight} + 4.2rem);
+                    margin-top: calc(-#{$headerHeight} - 4.2rem);
+                }
+            }
+        }
+
+        h4 {
+            font-size: $font-size--m;
+            border-bottom: 1px solid;
+            padding-top: 2.2rem;
+            padding-bottom: .15rem;
+            top: calc(#{$headerHeight} - 1rem);
+            margin-top: 0;
+            margin-bottom: 0;
+            z-index: $glossary-letter-z;
+        }
+
+        dl {
+            margin-left: 0;
+
+            dt {
+                list-style-type: none;
+                margin-bottom: 0;
+                margin-top: .9rem;
+                margin-left: 0;
+                text-transform: capitalize;
+            }
+
+            dd {
+                list-style-type: none;
+                margin-left: 1.5rem;
+            }
+        }
+    }
+}

--- a/assets/sass/term.scss
+++ b/assets/sass/term.scss
@@ -1,0 +1,101 @@
+@import "constants";
+
+.popover {
+    display: none;
+    z-index: $overlay-z;
+    color: $popoverTextColor;
+    background-color: $popoverBackgroundColor;
+    border-radius: $border-radius;
+    border: 1px solid $popoverBorderColor;
+    box-shadow: 3px 3px 8px $popoverShadowColor, -3px -3px 8px $popoverShadowColor;
+
+    max-width: 276px;
+    @media (min-width: $bp-md) {
+        max-width: 350px;
+    }
+
+    @media (min-width: $bp-xl) {
+        max-width: 500px;
+    }
+
+    &.show {
+        display: block;
+    }
+
+    .title {
+        text-align: center;
+        color: $popoverHeaderTextColor;
+        background-color: $popoverHeaderBackgroundColor;
+        font-size: 140%;
+        border-radius: $border-radius $border-radius 0 0;
+    }
+
+    .body {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    $arrow-width: 5px;
+    $arrow-height: 5px;
+
+    .arrow {
+        width: 0;
+        height: 0;
+        border-style: solid;
+        position: absolute;
+        border-color: transparent;
+    }
+
+    &[x-placement^=top] {
+        margin-bottom: $arrow-height;
+
+        .arrow {
+            border-width: $arrow-height $arrow-width 0 $arrow-height;
+            border-top-color: $popoverBackgroundColor;
+            bottom: -$arrow-height;
+            margin: 0 $arrow-width;
+        }
+    }
+
+    &[x-placement^=bottom] {
+        margin-top: $arrow-height;
+
+        .arrow {
+            border-width: 0 $arrow-width $arrow-height;
+            border-bottom-color: $popoverBackgroundColor;
+            top: -$arrow-height;
+            margin: 0 $arrow-width;
+        }
+    }
+
+    &[x-placement^=right] {
+        margin-left: $arrow-width;
+
+        .arrow {
+            border-width: $arrow-height $arrow-width $arrow-height 0;
+            border-right-color: $popoverBackgroundColor;
+            left: -$arrow-width;
+            margin: $arrow-height 0;
+        }
+    }
+
+    &[x-placement^=left] {
+        margin-right: $arrow-width;
+
+        .arrow {
+            border-width: $arrow-height 0 $arrow-width $arrow-height;
+            border-left-color: $popoverBackgroundColor;
+            right: -$arrow-width;
+            margin: $arrow-height 0;
+        }
+    }
+}
+
+.term {
+    @media screen {
+        border-bottom: dashed 1px;
+        cursor: help;
+        position: relative;
+        display: inline-block;
+    }
+}

--- a/content/concepts/glossary/index.en.md
+++ b/content/concepts/glossary/index.en.md
@@ -1,0 +1,11 @@
+---
+title: Glossary
+description: A glossary of common NeoFS terms
+icon: "ti-comments"
+type: "docs"
+date: "2021-12-29"
+weight: 100
+---
+
+{{<glossary>}}
+

--- a/content/concepts/glossary/mainnet.md
+++ b/content/concepts/glossary/mainnet.md
@@ -1,0 +1,7 @@
+---
+title: "Mainnet"
+---
+
+Main Network of Neo Blockchain. See [Neo Documentation](https://docs.neo.org/v3/docs/en-us/network/testnet.html)
+
+

--- a/content/concepts/glossary/neofs.md
+++ b/content/concepts/glossary/neofs.md
@@ -1,0 +1,6 @@
+---
+title: "NeoFS"
+---
+
+**N**eoFS **E**xaggerative **O**bject **F**ile **S**torage. Also known as **Neo** **F**ile **S**torage
+

--- a/content/concepts/glossary/object.md
+++ b/content/concepts/glossary/object.md
@@ -1,0 +1,7 @@
+---
+title: "Object"
+---
+
+An immutable piece of data with metadata in the form of a set of key-value headers. Object has a globally unique identifier.
+
+

--- a/content/concepts/glossary/validator.md
+++ b/content/concepts/glossary/validator.md
@@ -1,0 +1,6 @@
+---
+title: "Validator"
+---
+
+In the NEO network, NEO holders can enroll themselves to be validators (consensus node candidates), and then be voted as consensus nodes. The voting status of validators and number of consensus nodes are stored in blockchain.
+

--- a/content/concepts/what-is-neofs/_index.en.md
+++ b/content/concepts/what-is-neofs/_index.en.md
@@ -1,6 +1,7 @@
 ---
 title: "What is NeoFS?"
 date: "2021-12-07"
+weight: 1
 ---
 
 [NeoFS](https://fs.neo.org) is a decentralized distributed object storage system

--- a/layouts/shortcodes/glossary.html
+++ b/layouts/shortcodes/glossary.html
@@ -1,0 +1,54 @@
+
+<style>
+    .primary .article-container article {
+        overflow-x: visible;
+    }
+</style>
+
+{{ $styles := resources.Get "sass/glossary.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+<link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="screen">
+
+<div class="glossary">
+    {{- $glossary := .Site.GetPage "/concepts/glossary" -}}
+    {{- $words := $glossary.Resources.ByType "page" -}}
+
+    <div class="trampolines">
+        {{- $previous := "-" -}}
+
+        {{ range $w := $words }}
+            {{ $first := upper (slicestr $w.Title 0 1) }}
+
+            {{ if ne $first $previous }}
+                {{ if ne $previous "-" }}
+                    |
+                {{ end }}
+                <a href="#{{ $first }}" aria-label="Words starting with the letter {{ $first }}">{{ $first }}</a>
+                {{ $previous = $first }}
+            {{ end }}
+        {{ end }}
+    </div>
+
+    <div class="entries">
+        {{ $previous = "-" }}
+        {{ range $w := $words }}
+            {{ $first := upper (slicestr $w.Title 0 1) }}
+
+            {{ if ne $first $previous }}
+                {{ if ne $previous "-" }}
+                    </dl>
+                    </div>
+                {{ end }}
+                <div id="{{ $first }}" class="letter">
+                <h4>{{ $first }}</h4>
+                <dl>
+                {{ $previous = $first }}
+            {{ end }}
+
+            {{ $name := $w.Title | urlize }}
+            <dt id="{{ $name }}">{{ $w.Title }}</dt>
+            <dd aria-labelledby="{{ $name }}">{{ $w.Content }}</dd>
+        {{ end }}
+        </dl>
+        </div>
+    </div>
+</div>

--- a/layouts/shortcodes/term.html
+++ b/layouts/shortcodes/term.html
@@ -1,0 +1,28 @@
+{{ .Page.Scratch.Set "needPopper" true }}
+
+{{- $styles := resources.Get "sass/term.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint -}}
+<link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="screen">
+
+{{- $position := .Position }}
+{{- $term := .Inner -}}
+{{- $gloss_entry := $term -}}
+{{- if .Get 0 -}}
+    {{- $gloss_entry = .Get 0 -}}
+{{- end -}}
+
+{{- $glossary := .Site.GetPage "/concepts/glossary" -}}
+{{- $words := $glossary.Resources.ByType "page" -}}
+{{- $dfn := "" -}}
+{{- $title := $term -}}
+{{- range $w := $words -}}
+    {{- if (eq (upper $w.Title) (upper $gloss_entry)) -}}
+        {{- $dfn = $w.Content -}}
+        {{- $title = $w.Title -}}
+    {{- end -}}
+{{- end -}}
+
+{{- if (eq $dfn "") -}}
+    {{- errorf "Could not find glossary entry for '%s' (%s)" $gloss_entry $position -}}
+{{- end -}}
+
+<span class="term" data-title="{{- $title }}" data-body="{{- $dfn | string -}}">{{ $term }}</span>


### PR DESCRIPTION
Glossary shortcodes taken from https://github.com/istio/istio.io/ under the terms of Apache 2.0 license.

There are still style issues with `term` shortcode popover, but it works in general.
