### PR TITLE
*: use nspcc.io as the primary domain in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Welcome to the NeoFS Documentation site repository!
 
-This is a [NeoSPCC](https://nspcc.ru/en) maintained and community supported
+This is a [NeoSPCC](https://nspcc.io/) maintained and community supported
 NeoFS documentation project, where everyone can contribute new articles, suggest
 new topics and enhance existing content.
 

--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ link = "https://twitter.com/neospcc"
 languageName = "En"
 languageCode = "en-us"
 weight = 1
-copyright = "Copyright &copy; [NSPCC](https://nspcc.ru/) 2018-2021"
+copyright = "Copyright &copy; [NSPCC](https://nspcc.io/) 2018-2022"
 
 # banner
 [Languages.en.params.banner]


### PR DESCRIPTION
And fix copyright year.